### PR TITLE
リムライティングの計算が反映されるようにする

### DIFF
--- a/FuchidoriPop_Cutout.shader
+++ b/FuchidoriPop_Cutout.shader
@@ -600,7 +600,8 @@
                 fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
                 col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
 
-                col = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS) > 0. ? _RimColor : col;
+                fixed rim = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS);
+                col.rgb = lerp(col.rgb, _RimColor.rgb, rim);
 
                 fixed4 alphaMask = tex2D(_TransparentMask, i.uv);
                 col.a = col.a * OpenLitGray(alphaMask.rgb);
@@ -667,7 +668,8 @@
                 fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
                 col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
 
-                col = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS) > 0. ? _RimColor : col;
+                fixed rim = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS);
+                col.rgb = lerp(col.rgb, _RimColor.rgb, rim);
 
                 fixed4 alphaMask = tex2D(_TransparentMask, i.uv);
                 col.a = col.a * OpenLitGray(alphaMask.rgb);

--- a/FuchidoriPop_Cutout.shader
+++ b/FuchidoriPop_Cutout.shader
@@ -34,7 +34,7 @@
         [Space(10)]
         _RimColor("RimLightColor", Color) = (1., 1., 1., 1.)
         _RimLightStrength("RimLightStrength", Range(0., 1.)) = .5
-        _RimLightMask("RimLightMask", 2D) = "black" {}
+        _RimLightMask("RimLightMask", 2D) = "white" {}
 
         [Header(Outline)]
         [Space(10)]

--- a/FuchidoriPop_Opaque.shader
+++ b/FuchidoriPop_Opaque.shader
@@ -600,7 +600,8 @@
                 fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
                 col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
 
-                col = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS) > 0. ? _RimColor : col;
+                fixed rim = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS);
+                col.rgb = lerp(col.rgb, _RimColor.rgb, rim);
 
                 fixed4 alphaMask = tex2D(_TransparentMask, i.uv);
                 col.a = col.a * OpenLitGray(alphaMask.rgb);
@@ -667,7 +668,8 @@
                 fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
                 col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
 
-                col = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS) > 0. ? _RimColor : col;
+                fixed rim = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS);
+                col.rgb = lerp(col.rgb, _RimColor.rgb, rim);
 
                 fixed4 alphaMask = tex2D(_TransparentMask, i.uv);
                 col.a = col.a * OpenLitGray(alphaMask.rgb);

--- a/FuchidoriPop_Opaque.shader
+++ b/FuchidoriPop_Opaque.shader
@@ -34,7 +34,7 @@
         [Space(10)]
         _RimColor("RimLightColor", Color) = (1., 1., 1., 1.)
         _RimLightStrength("RimLightStrength", Range(0., 1.)) = .5
-        _RimLightMask("RimLightMask", 2D) = "black" {}
+        _RimLightMask("RimLightMask", 2D) = "white" {}
 
         [Header(Outline)]
         [Space(10)]

--- a/FuchidoriPop_Transparent.shader
+++ b/FuchidoriPop_Transparent.shader
@@ -600,7 +600,8 @@
                 fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
                 col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
 
-                col = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS) > 0. ? _RimColor : col;
+                fixed rim = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS);
+                col.rgb = lerp(col.rgb, _RimColor.rgb, rim);
 
                 fixed4 alphaMask = tex2D(_TransparentMask, i.uv);
                 col.a = col.a * OpenLitGray(alphaMask.rgb);
@@ -667,7 +668,8 @@
                 fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
                 col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
 
-                col = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS) > 0. ? _RimColor : col;
+                fixed rim = drawRimLighting(i.uv, i.screenPos, viewDir, i.normalWS);
+                col.rgb = lerp(col.rgb, _RimColor.rgb, rim);
 
                 fixed4 alphaMask = tex2D(_TransparentMask, i.uv);
                 col.a = col.a * OpenLitGray(alphaMask.rgb);

--- a/FuchidoriPop_Transparent.shader
+++ b/FuchidoriPop_Transparent.shader
@@ -34,7 +34,7 @@
         [Space(10)]
         _RimColor("RimLightColor", Color) = (1., 1., 1., 1.)
         _RimLightStrength("RimLightStrength", Range(0., 1.)) = .5
-        _RimLightMask("RimLightMask", 2D) = "black" {}
+        _RimLightMask("RimLightMask", 2D) = "white" {}
 
         [Header(Outline)]
         [Space(10)]


### PR DESCRIPTION
リムライティングの計算が以下原因で正常に行えていませんでした。
* RimLightMaskが存在しないと初期値が'black'のため常に計算されない。
* RimColorを直接colorに代入していた。

本修正で以下のように修正を行います。
* RimLightMaskが存在しない場合の初期値は'white'とする。
* RimColorはMainColorと計算結果の線形補間とする。