### PR TITLE
MonochromeLightingが反映できていなかった問題を修正

### DIFF
--- a/FuchidoriPop_Cutout.shader
+++ b/FuchidoriPop_Cutout.shader
@@ -1,4 +1,7 @@
-﻿Shader "FuchidoriPopToon/Cutout"
+﻿// Copyright (c) 2024 JohnTonarino
+// Released under the MIT license
+// FuchidoriPopToon v 1.0.0
+Shader "FuchidoriPopToon/Cutout"
 {
     Properties
     {
@@ -610,8 +613,8 @@
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
 
-                col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
                 col.rgb *= lerp(1., 1.+phoneSpec, _SpecularStrength);
+                col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
 
                 fixed3 albedo = col.rgb;
 #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
@@ -678,8 +681,8 @@
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
 
-                col.rgb *= lerp(0., OPENLIT_LIGHT_COLOR, factor*attenuation);
                 col.rgb *= lerp(1., 1.+phoneSpec, _SpecularStrength);
+                col.rgb *= lerp(0., OPENLIT_LIGHT_COLOR, factor*attenuation);
 
                 UNITY_APPLY_FOG(i.fogCoord, col);
 

--- a/FuchidoriPop_Opaque.shader
+++ b/FuchidoriPop_Opaque.shader
@@ -1,4 +1,7 @@
-﻿Shader "FuchidoriPopToon/Opaque"
+﻿// Copyright (c) 2024 JohnTonarino
+// Released under the MIT license
+// FuchidoriPopToon v 1.0.0
+Shader "FuchidoriPopToon/Opaque"
 {
     Properties
     {
@@ -610,8 +613,8 @@
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
 
-                col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
                 col.rgb *= lerp(1., 1.+phoneSpec, _SpecularStrength);
+                col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
 
                 fixed3 albedo = col.rgb;
 #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
@@ -678,8 +681,8 @@
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
 
-                col.rgb *= lerp(0., OPENLIT_LIGHT_COLOR, factor*attenuation);
                 col.rgb *= lerp(1., 1.+phoneSpec, _SpecularStrength);
+                col.rgb *= lerp(0., OPENLIT_LIGHT_COLOR, factor*attenuation);
 
                 UNITY_APPLY_FOG(i.fogCoord, col);
 

--- a/FuchidoriPop_Transparent.shader
+++ b/FuchidoriPop_Transparent.shader
@@ -1,4 +1,7 @@
-﻿Shader "FuchidoriPopToon/Transparent"
+﻿// Copyright (c) 2024 JohnTonarino
+// Released under the MIT license
+// FuchidoriPopToon v 1.0.0
+Shader "FuchidoriPopToon/Transparent"
 {
     Properties
     {
@@ -610,8 +613,8 @@
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
 
-                col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
                 col.rgb *= lerp(1., 1.+phoneSpec, _SpecularStrength);
+                col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
 
                 fixed3 albedo = col.rgb;
 #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH
@@ -678,8 +681,8 @@
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
 
-                col.rgb *= lerp(0., OPENLIT_LIGHT_COLOR, factor*attenuation);
                 col.rgb *= lerp(1., 1.+phoneSpec, _SpecularStrength);
+                col.rgb *= lerp(0., OPENLIT_LIGHT_COLOR, factor*attenuation);
 
                 UNITY_APPLY_FOG(i.fogCoord, col);
 


### PR DESCRIPTION
ライトの色をグレースケール化し乗算できていない問題を修正しました。

グレースケール化した色を載せた後に鏡面反射の計算結果を描画していたため、グレースケール化の処理が行われていないように見えていました。
