### PR TITLE
LightModeの記述を適切にする。特定のPostProcessing下でdepthが描かれるようにStencilRefの値を設定

### DIFF
--- a/FuchidoriPop_Cutout.shader
+++ b/FuchidoriPop_Cutout.shader
@@ -41,7 +41,7 @@ Shader "FuchidoriPopToon/Cutout"
 
         [Header(Outline)]
         [Space(10)]
-        _StencilRef("SencilRef", Int) = 127
+        _StencilRef("SencilRef", Int) = 2
         _OuterOutlineColor1st("OuterOutlineColor1st", Color) = (0.,0.,0.,1.)
         _OuterOutlineColor2nd("OuterOutlineColor2nd", Color) = (1.,1.,1.,1.)
         _InnerOutlineColor("InnerOutlineColor", Color) = (0.,0.,0.,1.)
@@ -574,13 +574,14 @@ Shader "FuchidoriPopToon/Cutout"
         // For ForwardBase Light
         Pass
         {
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp always
                 Pass replace
             }
             Cull back
-            Tags {"LightMode" = "ForwardBase"}
+
             BlendOp Add, Add
             Blend SrcAlpha OneMinusSrcAlpha
 
@@ -712,6 +713,7 @@ Shader "FuchidoriPopToon/Cutout"
         }
         // for stencil outer outline
         Pass{
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp NotEqual
@@ -765,6 +767,7 @@ Shader "FuchidoriPopToon/Cutout"
         }
         // for normal outline
         Pass{
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp Equal

--- a/FuchidoriPop_Opaque.shader
+++ b/FuchidoriPop_Opaque.shader
@@ -41,7 +41,7 @@ Shader "FuchidoriPopToon/Opaque"
 
         [Header(Outline)]
         [Space(10)]
-        _StencilRef("SencilRef", Int) = 127
+        _StencilRef("SencilRef", Int) = 2
         _OuterOutlineColor1st("OuterOutlineColor1st", Color) = (0.,0.,0.,1.)
         _OuterOutlineColor2nd("OuterOutlineColor2nd", Color) = (1.,1.,1.,1.)
         _InnerOutlineColor("InnerOutlineColor", Color) = (0.,0.,0.,1.)
@@ -574,13 +574,14 @@ Shader "FuchidoriPopToon/Opaque"
         // For ForwardBase Light
         Pass
         {
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp always
                 Pass replace
             }
             Cull back
-            Tags {"LightMode" = "ForwardBase"}
+
             BlendOp Add, Add
             Blend SrcAlpha OneMinusSrcAlpha
 
@@ -712,6 +713,7 @@ Shader "FuchidoriPopToon/Opaque"
         }
         // for stencil outer outline
         Pass{
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp NotEqual
@@ -765,6 +767,7 @@ Shader "FuchidoriPopToon/Opaque"
         }
         // for normal outline
         Pass{
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp Equal

--- a/FuchidoriPop_Transparent.shader
+++ b/FuchidoriPop_Transparent.shader
@@ -41,7 +41,7 @@ Shader "FuchidoriPopToon/Transparent"
 
         [Header(Outline)]
         [Space(10)]
-        _StencilRef("SencilRef", Int) = 127
+        _StencilRef("SencilRef", Int) = 2
         _OuterOutlineColor1st("OuterOutlineColor1st", Color) = (0.,0.,0.,1.)
         _OuterOutlineColor2nd("OuterOutlineColor2nd", Color) = (1.,1.,1.,1.)
         _InnerOutlineColor("InnerOutlineColor", Color) = (0.,0.,0.,1.)
@@ -574,13 +574,14 @@ Shader "FuchidoriPopToon/Transparent"
         // For ForwardBase Light
         Pass
         {
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp always
                 Pass replace
             }
             Cull back
-            Tags {"LightMode" = "ForwardBase"}
+
             BlendOp Add, Add
             Blend SrcAlpha OneMinusSrcAlpha
 
@@ -712,6 +713,7 @@ Shader "FuchidoriPopToon/Transparent"
         }
         // for stencil outer outline
         Pass{
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp NotEqual
@@ -765,6 +767,7 @@ Shader "FuchidoriPopToon/Transparent"
         }
         // for normal outline
         Pass{
+            Tags {"LightMode" = "ForwardBase"}
             Stencil{
                 Ref [_StencilRef]
                 Comp Equal


### PR DESCRIPTION
Tagsの記述が適切でない箇所の修正を行います。

また、Depthを使用する特定のPostProcessingでStencilが悪影響し正常に描画されない（透ける）問題を確認しました。Stencilの値によって発生することを確認したため、発生しないStencil値を初期値に設定してます。