### PR TITLE
ShadowTexがなくともShadowColorが反映されるように

### DIFF
--- a/FuchidoriPopToon_Cutout.shader
+++ b/FuchidoriPopToon_Cutout.shader
@@ -29,7 +29,7 @@ Shader "FuchidoriPopToon/Cutout"
 
         [Header(Shadow)]
         [Space(10)]
-        _ShadowTex("ShadowTex", 2D) = "black" {}
+        _ShadowTex("ShadowTex", 2D) = "white" {}
         _ShadowOverlayColor("ShadowOverlayColor", Color) = (0., 0., 0., 1.)
         _ShadowStrength("ShadowStrength",Range(0., 1.)) = 0.5
 

--- a/FuchidoriPopToon_Opaque.shader
+++ b/FuchidoriPopToon_Opaque.shader
@@ -29,7 +29,7 @@ Shader "FuchidoriPopToon/Opaque"
 
         [Header(Shadow)]
         [Space(10)]
-        _ShadowTex("ShadowTex", 2D) = "black" {}
+        _ShadowTex("ShadowTex", 2D) = "white" {}
         _ShadowOverlayColor("ShadowOverlayColor", Color) = (0., 0., 0., 1.)
         _ShadowStrength("ShadowStrength",Range(0., 1.)) = 0.5
 

--- a/FuchidoriPopToon_Transparent.shader
+++ b/FuchidoriPopToon_Transparent.shader
@@ -29,7 +29,7 @@ Shader "FuchidoriPopToon/Transparent"
 
         [Header(Shadow)]
         [Space(10)]
-        _ShadowTex("ShadowTex", 2D) = "black" {}
+        _ShadowTex("ShadowTex", 2D) = "white" {}
         _ShadowOverlayColor("ShadowOverlayColor", Color) = (0., 0., 0., 1.)
         _ShadowStrength("ShadowStrength",Range(0., 1.)) = 0.5
 


### PR DESCRIPTION
FuchidoriPopToonにはオブジェクトの影色を決めるためのパラメータであるShadowOverlayColorがあります。が、同様にShadowColorを設定するためのテクスチャであるShadowTexが設定されていない場合、ShadowTexがblack(0,0,0)で初期化されていることが原因で影色が反映されない不具合がありました。

本修正は上記初期値(black)をwhite(1,1,1)とすることでShaowOvelayColorに乗算しても0とならないようにすることで、影色を反映できるようにするためのものです。