### PR TITLE
Fix/impl outline shadow

### DIFF
--- a/FuchidoriPopToon_Cutout.shader
+++ b/FuchidoriPopToon_Cutout.shader
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2024 JohnTonarino
 // Released under the MIT license
-// FuchidoriPopToon v 1.0.1
-Shader "FuchidoriPopToon/Transparent"
+// FuchidoriPopToon v 1.0.2
+Shader "FuchidoriPopToon/Cutout"
 {
     Properties
     {
@@ -84,7 +84,7 @@ Shader "FuchidoriPopToon/Transparent"
     }
     SubShader
     {
-        Tags { "RenderType"="Transparent" "Queue"="Transparent"}
+        Tags { "RenderType"="TransparentCutout" "Queue"="AlphaTest"}
         LOD 100
 
         CGINCLUDE

--- a/FuchidoriPopToon_Cutout.shader
+++ b/FuchidoriPopToon_Cutout.shader
@@ -471,12 +471,12 @@ Shader "FuchidoriPopToon/Cutout"
             half2 viewUV : TEXCOORD11;
         };
 
-        float4 calcOutlineVertex(appdata v, fixed width){
-            float3 norm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, v.normalOS));
-            fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(v.uv.xy, 0., 0.));
+        float4 calcOutlineVertex(half3 normalOS, float2 uv, float4 vertex, fixed width){
+            float3 norm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, normalOS));
+            fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(uv.xy, 0., 0.));
             float2 offset = TransformViewToProjection(norm.xy)*outlineMask.r;
 
-            float4 outline_vertex = UnityObjectToClipPos(v.vertex);
+            float4 outline_vertex = UnityObjectToClipPos(vertex);
             outline_vertex.xy += (offset * width);
 
             return outline_vertex;
@@ -517,7 +517,7 @@ Shader "FuchidoriPopToon/Cutout"
 
             return o;
         }
-        g2f vert_normalbase(appdata v)
+        g2f vert_standardbase(appdata v)
         {
             g2f o;
             o = vert_base(v);
@@ -534,7 +534,7 @@ Shader "FuchidoriPopToon/Cutout"
         {
             g2f o;
             o = vert_base(v);
-            o.pos = calcOutlineVertex(v, width);
+            o.pos = calcOutlineVertex(v.normalOS, v.uv, v.vertex, width);
 
             // [OpenLit] Calculate and copy light datas
             OpenLitLightDatas lightDatas;
@@ -586,7 +586,7 @@ Shader "FuchidoriPopToon/Cutout"
             Blend SrcAlpha OneMinusSrcAlpha
 
             CGPROGRAM
-            #pragma vertex vert_normalbase
+            #pragma vertex vert_standardbase
             #pragma fragment frag
             #pragma multi_compile_fwdbase
             #pragma multi_compile_fog
@@ -655,7 +655,7 @@ Shader "FuchidoriPopToon/Cutout"
             Blend One One, Zero One
 
             CGPROGRAM
-            #pragma vertex vert_normalbase
+            #pragma vertex vert_standardbase
             #pragma fragment frag
             #pragma multi_compile_fwdadd
             #pragma multi_compile_fog
@@ -789,7 +789,7 @@ Shader "FuchidoriPopToon/Cutout"
             }
             ENDCG
         }
-        // For ShadowRendering
+        // For ShadowRendering (not for outline)
         Pass
         {
             Tags {"LightMode" = "ShadowCaster"}
@@ -811,6 +811,38 @@ Shader "FuchidoriPopToon/Cutout"
                 v2f_shadow o;
                 TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
                 o.pos = UnityObjectToClipPos(v.vertex);
+                o.uv = v.texcoord.xy;
+                o.screenPos = ComputeScreenPos(o.pos);
+                return o;
+            }
+            float4 frag(v2f_shadow i) : SV_Target
+            {
+                SHADOW_CASTER_FRAGMENT(i)
+            }
+            ENDCG
+        }
+        // For ShadowRendering (for outline)
+        Pass
+        {
+            Tags {"LightMode" = "ShadowCaster"}
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_shadowcaster
+            #include "UnityCG.cginc"
+
+            struct v2f_shadow {
+                V2F_SHADOW_CASTER;
+                float2 uv : TEXCOORD1;
+                float4 screenPos : TEXCOORD2;
+            };
+
+            v2f_shadow vert(appdata_base v)
+            {
+                v2f_shadow o;
+                TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
+                o.pos = calcOutlineVertex(v.normal, v.texcoord.xy, v.vertex, _OuterOutlineWidth);
                 o.uv = v.texcoord.xy;
                 o.screenPos = ComputeScreenPos(o.pos);
                 return o;

--- a/FuchidoriPopToon_Opaque.shader
+++ b/FuchidoriPopToon_Opaque.shader
@@ -471,12 +471,12 @@ Shader "FuchidoriPopToon/Opaque"
             half2 viewUV : TEXCOORD11;
         };
 
-        float4 calcOutlineVertex(appdata v, fixed width){
-            float3 norm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, v.normalOS));
-            fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(v.uv.xy, 0., 0.));
+        float4 calcOutlineVertex(half3 normalOS, float2 uv, float4 vertex, fixed width){
+            float3 norm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, normalOS));
+            fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(uv.xy, 0., 0.));
             float2 offset = TransformViewToProjection(norm.xy)*outlineMask.r;
 
-            float4 outline_vertex = UnityObjectToClipPos(v.vertex);
+            float4 outline_vertex = UnityObjectToClipPos(vertex);
             outline_vertex.xy += (offset * width);
 
             return outline_vertex;
@@ -517,7 +517,7 @@ Shader "FuchidoriPopToon/Opaque"
 
             return o;
         }
-        g2f vert_normalbase(appdata v)
+        g2f vert_standardbase(appdata v)
         {
             g2f o;
             o = vert_base(v);
@@ -534,7 +534,7 @@ Shader "FuchidoriPopToon/Opaque"
         {
             g2f o;
             o = vert_base(v);
-            o.pos = calcOutlineVertex(v, width);
+            o.pos = calcOutlineVertex(v.normalOS, v.uv, v.vertex, width);
 
             // [OpenLit] Calculate and copy light datas
             OpenLitLightDatas lightDatas;
@@ -586,7 +586,7 @@ Shader "FuchidoriPopToon/Opaque"
             Blend SrcAlpha OneMinusSrcAlpha
 
             CGPROGRAM
-            #pragma vertex vert_normalbase
+            #pragma vertex vert_standardbase
             #pragma fragment frag
             #pragma multi_compile_fwdbase
             #pragma multi_compile_fog
@@ -655,7 +655,7 @@ Shader "FuchidoriPopToon/Opaque"
             Blend One One, Zero One
 
             CGPROGRAM
-            #pragma vertex vert_normalbase
+            #pragma vertex vert_standardbase
             #pragma fragment frag
             #pragma multi_compile_fwdadd
             #pragma multi_compile_fog
@@ -789,7 +789,7 @@ Shader "FuchidoriPopToon/Opaque"
             }
             ENDCG
         }
-        // For ShadowRendering
+        // For ShadowRendering (not for outline)
         Pass
         {
             Tags {"LightMode" = "ShadowCaster"}
@@ -811,6 +811,38 @@ Shader "FuchidoriPopToon/Opaque"
                 v2f_shadow o;
                 TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
                 o.pos = UnityObjectToClipPos(v.vertex);
+                o.uv = v.texcoord.xy;
+                o.screenPos = ComputeScreenPos(o.pos);
+                return o;
+            }
+            float4 frag(v2f_shadow i) : SV_Target
+            {
+                SHADOW_CASTER_FRAGMENT(i)
+            }
+            ENDCG
+        }
+        // For ShadowRendering (for outline)
+        Pass
+        {
+            Tags {"LightMode" = "ShadowCaster"}
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_shadowcaster
+            #include "UnityCG.cginc"
+
+            struct v2f_shadow {
+                V2F_SHADOW_CASTER;
+                float2 uv : TEXCOORD1;
+                float4 screenPos : TEXCOORD2;
+            };
+
+            v2f_shadow vert(appdata_base v)
+            {
+                v2f_shadow o;
+                TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
+                o.pos = calcOutlineVertex(v.normal, v.texcoord.xy, v.vertex, _OuterOutlineWidth);
                 o.uv = v.texcoord.xy;
                 o.screenPos = ComputeScreenPos(o.pos);
                 return o;

--- a/FuchidoriPopToon_Opaque.shader
+++ b/FuchidoriPopToon_Opaque.shader
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2024 JohnTonarino
 // Released under the MIT license
-// FuchidoriPopToon v 1.0.1
-Shader "FuchidoriPopToon/Cutout"
+// FuchidoriPopToon v 1.0.2
+Shader "FuchidoriPopToon/Opaque"
 {
     Properties
     {
@@ -84,7 +84,7 @@ Shader "FuchidoriPopToon/Cutout"
     }
     SubShader
     {
-        Tags { "RenderType"="TransparentCutout" "Queue"="AlphaTest"}
+        Tags { "RenderType"="Opaque" "Queue"="Geometry"}
         LOD 100
 
         CGINCLUDE

--- a/FuchidoriPopToon_Transparent.shader
+++ b/FuchidoriPopToon_Transparent.shader
@@ -471,12 +471,12 @@ Shader "FuchidoriPopToon/Transparent"
             half2 viewUV : TEXCOORD11;
         };
 
-        float4 calcOutlineVertex(appdata v, fixed width){
-            float3 norm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, v.normalOS));
-            fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(v.uv.xy, 0., 0.));
+        float4 calcOutlineVertex(half3 normalOS, float2 uv, float4 vertex, fixed width){
+            float3 norm = normalize(mul((float3x3)UNITY_MATRIX_IT_MV, normalOS));
+            fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(uv.xy, 0., 0.));
             float2 offset = TransformViewToProjection(norm.xy)*outlineMask.r;
 
-            float4 outline_vertex = UnityObjectToClipPos(v.vertex);
+            float4 outline_vertex = UnityObjectToClipPos(vertex);
             outline_vertex.xy += (offset * width);
 
             return outline_vertex;
@@ -517,7 +517,7 @@ Shader "FuchidoriPopToon/Transparent"
 
             return o;
         }
-        g2f vert_normalbase(appdata v)
+        g2f vert_standardbase(appdata v)
         {
             g2f o;
             o = vert_base(v);
@@ -534,7 +534,7 @@ Shader "FuchidoriPopToon/Transparent"
         {
             g2f o;
             o = vert_base(v);
-            o.pos = calcOutlineVertex(v, width);
+            o.pos = calcOutlineVertex(v.normalOS, v.uv, v.vertex, width);
 
             // [OpenLit] Calculate and copy light datas
             OpenLitLightDatas lightDatas;
@@ -586,7 +586,7 @@ Shader "FuchidoriPopToon/Transparent"
             Blend SrcAlpha OneMinusSrcAlpha
 
             CGPROGRAM
-            #pragma vertex vert_normalbase
+            #pragma vertex vert_standardbase
             #pragma fragment frag
             #pragma multi_compile_fwdbase
             #pragma multi_compile_fog
@@ -655,7 +655,7 @@ Shader "FuchidoriPopToon/Transparent"
             Blend One One, Zero One
 
             CGPROGRAM
-            #pragma vertex vert_normalbase
+            #pragma vertex vert_standardbase
             #pragma fragment frag
             #pragma multi_compile_fwdadd
             #pragma multi_compile_fog
@@ -789,7 +789,7 @@ Shader "FuchidoriPopToon/Transparent"
             }
             ENDCG
         }
-        // For ShadowRendering
+        // For ShadowRendering (not for outline)
         Pass
         {
             Tags {"LightMode" = "ShadowCaster"}
@@ -811,6 +811,38 @@ Shader "FuchidoriPopToon/Transparent"
                 v2f_shadow o;
                 TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
                 o.pos = UnityObjectToClipPos(v.vertex);
+                o.uv = v.texcoord.xy;
+                o.screenPos = ComputeScreenPos(o.pos);
+                return o;
+            }
+            float4 frag(v2f_shadow i) : SV_Target
+            {
+                SHADOW_CASTER_FRAGMENT(i)
+            }
+            ENDCG
+        }
+        // For ShadowRendering (for outline)
+        Pass
+        {
+            Tags {"LightMode" = "ShadowCaster"}
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile_shadowcaster
+            #include "UnityCG.cginc"
+
+            struct v2f_shadow {
+                V2F_SHADOW_CASTER;
+                float2 uv : TEXCOORD1;
+                float4 screenPos : TEXCOORD2;
+            };
+
+            v2f_shadow vert(appdata_base v)
+            {
+                v2f_shadow o;
+                TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
+                o.pos = calcOutlineVertex(v.normal, v.texcoord.xy, v.vertex, _OuterOutlineWidth);
                 o.uv = v.texcoord.xy;
                 o.screenPos = ComputeScreenPos(o.pos);
                 return o;

--- a/FuchidoriPopToon_Transparent.shader
+++ b/FuchidoriPopToon_Transparent.shader
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2024 JohnTonarino
 // Released under the MIT license
-// FuchidoriPopToon v 1.0.1
-Shader "FuchidoriPopToon/Opaque"
+// FuchidoriPopToon v 1.0.2
+Shader "FuchidoriPopToon/Transparent"
 {
     Properties
     {
@@ -84,7 +84,7 @@ Shader "FuchidoriPopToon/Opaque"
     }
     SubShader
     {
-        Tags { "RenderType"="Opaque" "Queue"="Geometry"}
+        Tags { "RenderType"="Transparent" "Queue"="Transparent"}
         LOD 100
 
         CGINCLUDE

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ VRChatでの使用を想定したアウトラインにこだわりのあるシ�
 https://github.com/lilxyzw/OpenLit
 
 2024/05/05 1.0.0 リリース
+
 2024/05/06 1.0.1 OutlineMaskが有効になっていなかった不具合を修正。Outlineだけに対してLightの影響度を調整できるパラメータAsOutlineUnlitを追加。
 
+2024/05/11 1.0.2 リファクタリング。特定のPostProcessing影響下でStencilの値を原因として透過する現象が確認されたため、透過しないStencil値を初期値として設定。
 
 # 利用規約
 MITライセンスで公開しています。


### PR DESCRIPTION
OutlineのShadowを描けるようにします。

これによりOutlineのDepthTextureに深度が書きこまれるので、PostProcessing影響下でOutline部が透過しないことが期待できます。