### PR TITLE
影の境界をぼかす

### DIFF
--- a/FuchidoriPopToon_Opaque.shader
+++ b/FuchidoriPopToon_Opaque.shader
@@ -33,6 +33,7 @@ Shader "FuchidoriPopToon/Opaque"
         _ShadowOverlayColor1st("ShadowOverlayColor1st", Color) = (0., 0., 0., 1.)
         _ShadowOverlayColor2nd("ShadowOverlayColor2nd", Color) = (0., 0., 0., 1.)
         _ShadowWidth("ShadowWidth",Range(0., 1.)) = 0.5
+        _ShadowEdgeSmoothness("ShadowEdgeSmoothness",Range(0., 1.)) = 0.05
         _ShadowStrength("ShadowStrength",Range(0., 1.)) = 0.5
 
         [Header(RimColor)]
@@ -410,6 +411,7 @@ Shader "FuchidoriPopToon/Opaque"
         fixed4 _ShadowOverlayColor1st;
         fixed4 _ShadowOverlayColor2nd;
         half _ShadowWidth;
+        half _ShadowEdgeSmoothness;
         half _ShadowStrength;
 
         fixed4 _RimColor;
@@ -627,7 +629,12 @@ Shader "FuchidoriPopToon/Opaque"
                 fixed4 shadowTexColor = tex2D(_ShadowTex, i.uv);
                 fixed4 shadowColor1st = shadowTexColor * _ShadowOverlayColor1st;
                 fixed4 shadowColor2nd = shadowTexColor * _ShadowOverlayColor2nd;
-                fixed3 factor;
+                float  shadowBlend = smoothstep(NdotL-_ShadowEdgeSmoothness, NdotL+_ShadowEdgeSmoothness, NdotL*NdotL-_ShadowWidth);
+                fixed3 shadowColor = lerp(shadowColor1st.rgb, shadowColor2nd.rgb, shadowBlend);
+
+                fixed3 factor = 0.;
+                float factorBlend = 0.;
+
                 if(_SDFOn){
                     half3 right = unity_ObjectToWorld._m00_m10_m20;
                     half3 up = unity_ObjectToWorld._m01_m11_m21;
@@ -645,16 +652,13 @@ Shader "FuchidoriPopToon/Opaque"
                     float normalizedFdotL = .5*FdotL+.5;
                     normalizedFdotL%=1.;
 
-                    factor = 1-step(faceShadowMap,normalizedFdotL);
-                    factor = factor > _ShadowThreshold ? factor :
-                                NdotL+_ShadowWidth > NdotL*NdotL?
-                                    shadowColor1st.rgb:shadowColor2nd.rgb;
+                    factor = 1.-smoothstep(faceShadowMap-_ShadowEdgeSmoothness, faceShadowMap+_ShadowEdgeSmoothness, normalizedFdotL);
+                    factorBlend = smoothstep(_ShadowThreshold-_ShadowEdgeSmoothness, _ShadowThreshold+_ShadowEdgeSmoothness, factor);
                 }
                 else{
-                    factor = NdotL > _ShadowThreshold ? 1 : 
-                                NdotL+_ShadowWidth > NdotL*NdotL?
-                                    shadowColor1st.rgb:shadowColor2nd.rgb;
+                    factorBlend = smoothstep(_ShadowThreshold-_ShadowEdgeSmoothness, _ShadowThreshold+_ShadowEdgeSmoothness, NdotL);
                 }
+                factor = lerp(shadowColor, 1., factorBlend);
                 factor = lerp(1., factor, _ShadowStrength);
                 if (_ReceiveShadow) factor *= attenuation;
 
@@ -729,9 +733,11 @@ Shader "FuchidoriPopToon/Opaque"
                 fixed4 shadowTexColor = tex2D(_ShadowTex, i.uv);
                 fixed4 shadowColor1st = shadowTexColor * _ShadowOverlayColor1st;
                 fixed4 shadowColor2nd = shadowTexColor * _ShadowOverlayColor2nd;
-                fixed3 factor = NdotL > _ShadowThreshold ? 1 :
-                                NdotL+_ShadowWidth > NdotL*NdotL?
-                                    shadowColor1st.rgb:shadowColor2nd.rgb;
+                float  shadowBlend = smoothstep(NdotL-_ShadowEdgeSmoothness, NdotL+_ShadowEdgeSmoothness, NdotL*NdotL-_ShadowWidth);
+                fixed3 shadowColor = lerp(shadowColor1st.rgb, shadowColor2nd.rgb, shadowBlend);
+
+                float factorBlend = smoothstep(_ShadowThreshold-_ShadowEdgeSmoothness, _ShadowThreshold+_ShadowEdgeSmoothness, NdotL);
+                fixed3 factor = lerp(shadowColor, 1., factorBlend);
                 factor = lerp(1., factor, _ShadowStrength);
 
                 fixed4 col = tex2D(_MainTex, i.uv) * _MainTexOverlayColor;

--- a/FuchidoriPopToon_Transparent.shader
+++ b/FuchidoriPopToon_Transparent.shader
@@ -33,6 +33,7 @@ Shader "FuchidoriPopToon/Transparent"
         _ShadowOverlayColor1st("ShadowOverlayColor1st", Color) = (0., 0., 0., 1.)
         _ShadowOverlayColor2nd("ShadowOverlayColor2nd", Color) = (0., 0., 0., 1.)
         _ShadowWidth("ShadowWidth",Range(0., 1.)) = 0.5
+        _ShadowEdgeSmoothness("ShadowEdgeSmoothness",Range(0., 1.)) = 0.05
         _ShadowStrength("ShadowStrength",Range(0., 1.)) = 0.5
 
         [Header(RimColor)]
@@ -410,6 +411,7 @@ Shader "FuchidoriPopToon/Transparent"
         fixed4 _ShadowOverlayColor1st;
         fixed4 _ShadowOverlayColor2nd;
         half _ShadowWidth;
+        half _ShadowEdgeSmoothness;
         half _ShadowStrength;
 
         fixed4 _RimColor;
@@ -627,7 +629,12 @@ Shader "FuchidoriPopToon/Transparent"
                 fixed4 shadowTexColor = tex2D(_ShadowTex, i.uv);
                 fixed4 shadowColor1st = shadowTexColor * _ShadowOverlayColor1st;
                 fixed4 shadowColor2nd = shadowTexColor * _ShadowOverlayColor2nd;
-                fixed3 factor;
+                float  shadowBlend = smoothstep(NdotL-_ShadowEdgeSmoothness, NdotL+_ShadowEdgeSmoothness, NdotL*NdotL-_ShadowWidth);
+                fixed3 shadowColor = lerp(shadowColor1st.rgb, shadowColor2nd.rgb, shadowBlend);
+
+                fixed3 factor = 0.;
+                float factorBlend = 0.;
+
                 if(_SDFOn){
                     half3 right = unity_ObjectToWorld._m00_m10_m20;
                     half3 up = unity_ObjectToWorld._m01_m11_m21;
@@ -645,16 +652,13 @@ Shader "FuchidoriPopToon/Transparent"
                     float normalizedFdotL = .5*FdotL+.5;
                     normalizedFdotL%=1.;
 
-                    factor = 1-step(faceShadowMap,normalizedFdotL);
-                    factor = factor > _ShadowThreshold ? factor :
-                                NdotL+_ShadowWidth > NdotL*NdotL?
-                                    shadowColor1st.rgb:shadowColor2nd.rgb;
+                    factor = 1.-smoothstep(faceShadowMap-_ShadowEdgeSmoothness, faceShadowMap+_ShadowEdgeSmoothness, normalizedFdotL);
+                    factorBlend = smoothstep(_ShadowThreshold-_ShadowEdgeSmoothness, _ShadowThreshold+_ShadowEdgeSmoothness, factor);
                 }
                 else{
-                    factor = NdotL > _ShadowThreshold ? 1 : 
-                                NdotL+_ShadowWidth > NdotL*NdotL?
-                                    shadowColor1st.rgb:shadowColor2nd.rgb;
+                    factorBlend = smoothstep(_ShadowThreshold-_ShadowEdgeSmoothness, _ShadowThreshold+_ShadowEdgeSmoothness, NdotL);
                 }
+                factor = lerp(shadowColor, 1., factorBlend);
                 factor = lerp(1., factor, _ShadowStrength);
                 if (_ReceiveShadow) factor *= attenuation;
 
@@ -671,7 +675,6 @@ Shader "FuchidoriPopToon/Transparent"
 
                 fixed4 emissiveTex = tex2D(_EmissiveTex, i.uv);
                 col.rgb += emissiveTex.rgb * _EmissiveColor;
-
 
                 half3 refDir = reflect(-viewDir, i.normalWS);
                 half3 mip = (1 - _Smoothness) * (1.7 - .7 * (1 - _Smoothness)) * UNITY_SPECCUBE_LOD_STEPS;
@@ -730,9 +733,11 @@ Shader "FuchidoriPopToon/Transparent"
                 fixed4 shadowTexColor = tex2D(_ShadowTex, i.uv);
                 fixed4 shadowColor1st = shadowTexColor * _ShadowOverlayColor1st;
                 fixed4 shadowColor2nd = shadowTexColor * _ShadowOverlayColor2nd;
-                fixed3 factor = NdotL > _ShadowThreshold ? 1 :
-                                NdotL+_ShadowWidth > NdotL*NdotL?
-                                    shadowColor1st.rgb:shadowColor2nd.rgb;
+                float  shadowBlend = smoothstep(NdotL-_ShadowEdgeSmoothness, NdotL+_ShadowEdgeSmoothness, NdotL*NdotL-_ShadowWidth);
+                fixed3 shadowColor = lerp(shadowColor1st.rgb, shadowColor2nd.rgb, shadowBlend);
+
+                float factorBlend = smoothstep(_ShadowThreshold-_ShadowEdgeSmoothness, _ShadowThreshold+_ShadowEdgeSmoothness, NdotL);
+                fixed3 factor = lerp(shadowColor, 1., factorBlend);
                 factor = lerp(1., factor, _ShadowStrength);
 
                 fixed4 col = tex2D(_MainTex, i.uv) * _MainTexOverlayColor;


### PR DESCRIPTION
現在のシェーダーでは影の境界にstep()を使用しているため、境界がきっぱりと分かれています。

smoothstepを使用したこの修正を取り込むことで、より自然に寄せた影の境界の表現ができるようになります。