### PR TITLE
MatCapの計算で線形補間だけでなく乗算もできるように

### DIFF
--- a/Includes/FPT_Core.cginc
+++ b/Includes/FPT_Core.cginc
@@ -22,6 +22,7 @@ half _BumpScale;
 sampler2D _BumpMap;
 float4 _BumpMap_ST;
 
+uint _MatCapType;
 sampler2D _MatCap;
 half _MatCapStrength;
 sampler2D _MatCapMask;

--- a/Includes/FPT_Core.cginc
+++ b/Includes/FPT_Core.cginc
@@ -61,8 +61,8 @@ half _TransparentLevel;
 sampler2D _EmissiveTex;
 float4 _EmissiveColor;
 
-uint _VRCLightVolumeOn;
-half _VRCLightVolumeStrength;
+uint _VRCLightVolumesOn;
+half _VRCLightVolumesStrength;
 
 // [OpenLit] Properties for lighting
 float _LightIntensity;

--- a/Includes/FPT_Lighting.cginc
+++ b/Includes/FPT_Lighting.cginc
@@ -25,11 +25,7 @@ fixed3 lv_SampleVolumes(fixed3 albedo, g2f i, float3 viewDir) {
     // Diffuse Contribution from Light Volumes
     fixed3 LVEvaluate = LightVolumeEvaluate(i.normalWS, lv_L0, lv_L1r, lv_L1g, lv_L1b);
 
-    // Specular Contribution from Light Volumes
-    fixed3 LVSpecular = LightVolumeSpecular(albedo, _Smoothness, 0.0, i.normalWS, viewDir, lv_L0, lv_L1r, lv_L1g, lv_L1b);
-
-    // Light Volume の拡散光はアルベドに乗算して加算
-    return LVEvaluate * albedo + LVSpecular;
+    return LVEvaluate * albedo;
 }
 
 g2f vert_main_pass(appdata v)

--- a/Includes/FPT_Lighting.cginc
+++ b/Includes/FPT_Lighting.cginc
@@ -88,7 +88,9 @@ fixed3 CalculateShadow(g2f i, float3 N, float3 L, float NdotL){
 void CalculateMaterialEffects(inout fixed4 col, g2f i, float3 viewDir) {
     // MatCap
     fixed4 matcap = tex2D(_MatCap, i.viewUV) * tex2D(_MatCapMask, i.uv);
-    col.rgb = lerp(col.rgb, matcap.rgb, _MatCapStrength);
+    col.rgb = _MatCapType==0?
+                lerp(col.rgb, matcap.rgb, _MatCapStrength):
+                col.rgb*lerp(1., matcap.rgb, _MatCapStrength);
 
     // RimLighting
     fixed rim = fpt_rimLighting(i.uv, i.screenPos, viewDir, i.normalWS);

--- a/Sources/FuchidoriPopToon_Cutout.shader
+++ b/Sources/FuchidoriPopToon_Cutout.shader
@@ -18,6 +18,7 @@ Shader "FuchidoriPopToon/Cutout"
         [Header(MatCap)]
         [Space(10)]
         _MatCap("MatCap", 2D) = "white" {}
+        [Enum(Lerp,0,Mul,1)]_MatCapType ("MatCapCalcType", int) = 0
         _MatCapStrength("MatCapStrength", Range(0., 1.)) = 0.
         _MatCapMask("MatCapMask", 2D) = "white" {}
 

--- a/Sources/FuchidoriPopToon_Cutout.shader
+++ b/Sources/FuchidoriPopToon_Cutout.shader
@@ -69,8 +69,8 @@ Shader "FuchidoriPopToon/Cutout"
 
         [Header(ExperimentalFeature)]
         [Space(10)]
-        [Toggle(_)] _VRCLightVolumeOn("VRCLightVolume(Experimental)", Int) = 0
-        _VRCLightVolumeStrength("VRCLightVolumeStrength", Range(0., 1.)) = 1.
+        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes(Experimental)", Int) = 0
+        _VRCLightVolumesStrength("VRCLightVolumesStrength", Range(0., 1.)) = 1.
 
         //------------------------------------------------------------------------------------------------------------------------------
         // [OpenLit] Properties for lighting
@@ -153,8 +153,8 @@ Shader "FuchidoriPopToon/Cutout"
                 CalculateMaterialEffects(col, i, viewDir);
 
                 col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
-                if(_VRCLightVolumeOn){
-                    col.rgb += _VRCLightVolumeStrength*lv_SampleVolumes(albedo, i, viewDir);
+                if(_VRCLightVolumesOn){
+                    col.rgb += _VRCLightVolumesStrength*lv_SampleVolumes(albedo, i, viewDir);
                 }
 
 #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH

--- a/Sources/FuchidoriPopToon_Opaque.shader
+++ b/Sources/FuchidoriPopToon_Opaque.shader
@@ -18,6 +18,7 @@ Shader "FuchidoriPopToon/Opaque"
         [Header(MatCap)]
         [Space(10)]
         _MatCap("MatCap", 2D) = "white" {}
+        [Enum(Lerp,0,Mul,1)]_MatCapType ("MatCapCalcType", int) = 0
         _MatCapStrength("MatCapStrength", Range(0., 1.)) = 0.
         _MatCapMask("MatCapMask", 2D) = "white" {}
 

--- a/Sources/FuchidoriPopToon_Opaque.shader
+++ b/Sources/FuchidoriPopToon_Opaque.shader
@@ -69,8 +69,8 @@ Shader "FuchidoriPopToon/Opaque"
 
         [Header(ExperimentalFeature)]
         [Space(10)]
-        [Toggle(_)] _VRCLightVolumeOn("VRCLightVolume(Experimental)", Int) = 0
-        _VRCLightVolumeStrength("VRCLightVolumeStrength", Range(0., 1.)) = 1.
+        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes(Experimental)", Int) = 0
+        _VRCLightVolumesStrength("VRCLightVolumesStrength", Range(0., 1.)) = 1.
 
         //------------------------------------------------------------------------------------------------------------------------------
         // [OpenLit] Properties for lighting
@@ -153,9 +153,9 @@ Shader "FuchidoriPopToon/Opaque"
                 CalculateMaterialEffects(col, i, viewDir);
 
                 col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
-                if(_VRCLightVolumeOn){
+                if(_VRCLightVolumesOn){
                     fixed3 lvContribution = lv_SampleVolumes(albedo, i, viewDir);
-                    col.rgb = lerp(col.rgb, col.rgb+lvContribution, _VRCLightVolumeStrength);
+                    col.rgb = lerp(col.rgb, col.rgb+lvContribution, _VRCLightVolumesStrength);
                 }
 
 #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH

--- a/Sources/FuchidoriPopToon_Transparent.shader
+++ b/Sources/FuchidoriPopToon_Transparent.shader
@@ -69,8 +69,8 @@ Shader "FuchidoriPopToon/Transparent"
 
         [Header(ExperimentalFeature)]
         [Space(10)]
-        [Toggle(_)] _VRCLightVolumeOn("VRCLightVolume(Experimental)", Int) = 0
-        _VRCLightVolumeStrength("VRCLightVolumeStrength", Range(0., 1.)) = 1.
+        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes(Experimental)", Int) = 0
+        _VRCLightVolumesStrength("VRCLightVolumesStrength", Range(0., 1.)) = 1.
 
         //------------------------------------------------------------------------------------------------------------------------------
         // [OpenLit] Properties for lighting
@@ -153,8 +153,8 @@ Shader "FuchidoriPopToon/Transparent"
                 CalculateMaterialEffects(col, i, viewDir);
 
                 col.rgb *= lerp(lightDatas.indirectLight, lightDatas.directLight, factor);
-                if(_VRCLightVolumeOn){
-                    col.rgb += _VRCLightVolumeStrength*lv_SampleVolumes(albedo, i, viewDir);
+                if(_VRCLightVolumesOn){
+                    col.rgb += _VRCLightVolumesStrength*lv_SampleVolumes(albedo, i, viewDir);
                 }
 
 #if !defined(LIGHTMAP_ON) && UNITY_SHOULD_SAMPLE_SH

--- a/Sources/FuchidoriPopToon_Transparent.shader
+++ b/Sources/FuchidoriPopToon_Transparent.shader
@@ -18,6 +18,7 @@ Shader "FuchidoriPopToon/Transparent"
         [Header(MatCap)]
         [Space(10)]
         _MatCap("MatCap", 2D) = "white" {}
+        [Enum(Lerp,0,Mul,1)]_MatCapType ("MatCapCalcType", int) = 0
         _MatCapStrength("MatCapStrength", Range(0., 1.)) = 0.
         _MatCapMask("MatCapMask", 2D) = "white" {}
 


### PR DESCRIPTION
従来MatCapの計算では線形補間のみを使うような実装にしていましたが、乗算も行えるようにします。