### PR TITLE
頂点カラーにアウトライン用ノーマルをベイクする方法に対応する

### DIFF
--- a/Includes/FPT_Core.cginc
+++ b/Includes/FPT_Core.cginc
@@ -53,6 +53,7 @@ fixed _OuterOutlineWidth;
 fixed _InnerOutlineWidth;
 half   _OutlineWidth;
 sampler2D _OutlineMask;
+uint _VertexColorNormal;
 half   _AsOutlineUnlit;
 
 sampler2D _TransparentMask;
@@ -84,8 +85,9 @@ struct appdata
     float4 vertex : POSITION;
     float2 uv : TEXCOORD0;
     float2 uv1 : TEXCOORD1;
-    half3 normalOS : NORMAL;
-    half4 tangent : TANGENT;
+    float3 normalOS : NORMAL;
+    float4 tangent : TANGENT;
+    fixed4 color : COLOR;
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
@@ -95,8 +97,6 @@ struct g2f
     float3 positionWS : TEXCOORD0;
     float2 uv : TEXCOORD1;
     float3 normalWS : TEXCOORD2;
-
-    fixed4 color : COLOR;
 
     // [OpenLit] Add light datas
     nointerpolation uint3 lightDatas : TEXCOORD3;
@@ -110,6 +110,8 @@ struct g2f
     half3 tangent : TEXCOORD9;
     half3 binormal : TEXCOORD10;
     half2 viewUV : TEXCOORD11;
+
+    fixed4 color : TEXCOORD12;
 };
 
 struct v2f_shadow {

--- a/Includes/FPT_Core.cginc
+++ b/Includes/FPT_Core.cginc
@@ -151,5 +151,17 @@ g2f vert_base (appdata v)
     return o;
 }
 
+g2f vert_main_pass(appdata v)
+{
+    g2f o;
+    o = vert_base(v);
 
+    // [OpenLit] Calculate and copy light datas
+    OpenLitLightDatas lightDatas;
+    ComputeLights(lightDatas, _LightDirectionOverride);
+    CorrectLights(lightDatas, _LightMinLimit, _LightMaxLimit, _MonochromeLighting, _AsUnlit);
+    PackLightDatas(o.lightDatas, lightDatas);
+
+    return o;
+}
 #endif // FPT_CORE_INCLUDED

--- a/Includes/FPT_Lighting.cginc
+++ b/Includes/FPT_Lighting.cginc
@@ -28,20 +28,6 @@ fixed3 lv_SampleVolumes(fixed3 albedo, g2f i, float3 viewDir) {
     return LVEvaluate * albedo;
 }
 
-g2f vert_main_pass(appdata v)
-{
-    g2f o;
-    o = vert_base(v);
-
-    // [OpenLit] Calculate and copy light datas
-    OpenLitLightDatas lightDatas;
-    ComputeLights(lightDatas, _LightDirectionOverride);
-    CorrectLights(lightDatas, _LightMinLimit, _LightMaxLimit, _MonochromeLighting, _AsUnlit);
-    PackLightDatas(o.lightDatas, lightDatas);
-
-    return o;
-}
-
 fixed3 CalculateShadow(g2f i, float3 N, float3 L, float NdotL){
     fixed4 shadowTexColor = tex2D(_ShadowTex, i.uv);
     fixed4 shadowColor1st = shadowTexColor * _ShadowOverlayColor1st;

--- a/Includes/FPT_Outline.cginc
+++ b/Includes/FPT_Outline.cginc
@@ -45,6 +45,19 @@ float2 CalculateOffsetVectorNormal(float3 normalOS, float2 uv){
     return offsetVector;
 }
 
+g2f vert_outlinebase(appdata v) {
+    g2f o;
+    o = vert_base(v);
+
+    // [OpenLit] Calculate and copy light datas
+    OpenLitLightDatas lightDatas;
+    ComputeLights(lightDatas, _LightDirectionOverride);
+    CorrectLights(lightDatas, _LightMinLimit, _LightMaxLimit, _MonochromeLighting, _AsOutlineUnlit);
+    PackLightDatas(o.lightDatas, lightDatas);
+
+    return o;
+}
+
 fixed4 frag_outline(g2f i) : SV_Target
 {
     UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
@@ -90,7 +103,7 @@ void geom_outline(triangle appdata IN[3], inout TriangleStream<g2f> stream) {
     // 1st Outline
     [unroll]for (int j = 0; j < 3; ++j) {
         appdata v = IN[j];
-        o = vert_main_pass(v);
+        o = vert_outlinebase(v);
         o.pos.xy += (offsets[j] * _OuterOutlineRatio * _OuterOutlineWidth);
         o.color = _OuterOutlineColor1st;
         UNITY_TRANSFER_FOG(o, o.pos);
@@ -102,7 +115,7 @@ void geom_outline(triangle appdata IN[3], inout TriangleStream<g2f> stream) {
     // 2nd Outline
     [unroll]for (int k = 0; k < 3; ++k) {
         appdata v = IN[k];
-        o = vert_main_pass(v);
+        o = vert_outlinebase(v);
         o.pos.xy += (offsets[k] * _OuterOutlineWidth);
         o.color = _OuterOutlineColor2nd;
         UNITY_TRANSFER_FOG(o, o.pos);

--- a/Includes/FPT_Outline.cginc
+++ b/Includes/FPT_Outline.cginc
@@ -7,7 +7,33 @@
 
 #include "FPT_Core.cginc"
 
-float4 CalculateOutlineVertex(half3 normalOS, float2 uv, float4 vertex, fixed width){
+float3 CalculateOutlineVectorWS(float4 color, float3 normalOS, float4 tangentOS)
+{
+    float3 normalWS = UnityObjectToWorldNormal(normalOS);
+    float3 tangentWS = UnityObjectToWorldDir(tangentOS.xyz);
+    float3 bitangentWS = cross(normalWS, tangentWS.xyz) * tangentOS.w * unity_WorldTransformParams.w;
+
+    float3 outlineVectorTS = color.rgb * 2.0 - 1.0;
+    float3 outlineVector = outlineVectorTS.x * tangentWS.xyz + outlineVectorTS.y * bitangentWS + outlineVectorTS.z * normalWS;
+    return outlineVector * color.a;
+}
+
+float2 CalculateOffsetVectorVertex(fixed4 color, float3 normalOS, float4 tangentOS, float2 uv, float4 vertex){
+
+    float3 outlineVector = CalculateOutlineVectorWS(color, normalOS, tangentOS);
+    outlineVector = normalize(outlineVector);
+
+    float3 norm = mul((float3x3)UNITY_MATRIX_V, outlineVector);
+    
+    float normLength = length(norm);
+    norm = normLength > 0.0001 ? norm / normLength : float3(0, 0, 1);
+
+    fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(uv.xy, 0., 0.));
+    float2 offsetVector = TransformViewToProjection(norm.xy)*outlineMask.r;
+    return offsetVector;
+}
+
+float2 CalculateOffsetVectorNormal(float3 normalOS, float2 uv){
     float3 normalWS = UnityObjectToWorldNormal(normalOS);
     float3 norm = mul((float3x3)UNITY_MATRIX_V, normalWS);
     
@@ -15,27 +41,8 @@ float4 CalculateOutlineVertex(half3 normalOS, float2 uv, float4 vertex, fixed wi
     norm = normLength > 0.0001 ? norm / normLength : float3(0, 0, 1);
 
     fixed4 outlineMask = tex2Dlod(_OutlineMask, float4(uv.xy, 0., 0.));
-    float2 offset = TransformViewToProjection(norm.xy)*outlineMask.r;
-
-    float4 outline_vertex = UnityObjectToClipPos(vertex);
-    outline_vertex.xy += (offset * width);
-
-    return outline_vertex;
-}
-
-g2f vert_outlinebase(appdata v, fixed width)
-{
-    g2f o;
-    o = vert_base(v);
-    o.pos = CalculateOutlineVertex(v.normalOS, v.uv, v.vertex, width);
-
-    // [OpenLit] Calculate and copy light datas
-    OpenLitLightDatas lightDatas;
-    ComputeLights(lightDatas, _LightDirectionOverride);
-    CorrectLights(lightDatas, _LightMinLimit, _LightMaxLimit, _MonochromeLighting, _AsOutlineUnlit);
-    PackLightDatas(o.lightDatas, lightDatas);
-
-    return o;
+    float2 offsetVector = TransformViewToProjection(norm.xy)*outlineMask.r;
+    return offsetVector;
 }
 
 fixed4 frag_outline(g2f i) : SV_Target
@@ -72,10 +79,19 @@ void geom_outline(triangle appdata IN[3], inout TriangleStream<g2f> stream) {
     UNITY_SETUP_INSTANCE_ID(IN[2]);
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-    // 1st Outline
-    for (int i = 0; i < 3; ++i) {
+    float2 offsets[3];
+    [unroll]for (int i = 0; i < 3; ++i) {
         appdata v = IN[i];
-        o = vert_outlinebase(v, _OuterOutlineRatio * _OuterOutlineWidth);
+        offsets[i] = (_VertexColorNormal == 1) ?
+            CalculateOffsetVectorVertex(v.color, v.normalOS, v.tangent, v.uv, v.vertex):
+            CalculateOffsetVectorNormal(v.normalOS, v.uv);
+    }
+
+    // 1st Outline
+    [unroll]for (int j = 0; j < 3; ++j) {
+        appdata v = IN[j];
+        o = vert_main_pass(v);
+        o.pos.xy += (offsets[j] * _OuterOutlineRatio * _OuterOutlineWidth);
         o.color = _OuterOutlineColor1st;
         UNITY_TRANSFER_FOG(o, o.pos);
 
@@ -84,9 +100,10 @@ void geom_outline(triangle appdata IN[3], inout TriangleStream<g2f> stream) {
     stream.RestartStrip();
 
     // 2nd Outline
-    for (int j = 0; j < 3; ++j) {
-        appdata v = IN[j];
-        o = vert_outlinebase(v, _OuterOutlineWidth);
+    [unroll]for (int k = 0; k < 3; ++k) {
+        appdata v = IN[k];
+        o = vert_main_pass(v);
+        o.pos.xy += (offsets[k] * _OuterOutlineWidth);
         o.color = _OuterOutlineColor2nd;
         UNITY_TRANSFER_FOG(o, o.pos);
 

--- a/Sources/FuchidoriPopToon_Cutout.shader
+++ b/Sources/FuchidoriPopToon_Cutout.shader
@@ -55,6 +55,7 @@ Shader "FuchidoriPopToon/Cutout"
         _OuterOutlineRatio("OuterOutlineRatio", Range(.01, 1.)) = .3
         _InnerOutlineWidth("InnerOutlineWidth", Float) = .0015
         _OutlineMask("OutlineMask", 2D) = "white" {}
+        [Toggle(_)] _VertexColorNormal("VertexColorNormal", Int) = 0
         _AsOutlineUnlit("As OutlineUnlit", Range(0,1)) = 0.5
 
         [Header(Transparent)]
@@ -67,9 +68,9 @@ Shader "FuchidoriPopToon/Cutout"
         _EmissiveTex("EmissiveTex", 2D) = "black" {}
         [HDR] _EmissiveColor("EmissiveColor", Color) = (1., 1., 1., 1.)
 
-        [Header(ExperimentalFeature)]
+        [Header(VRCLightVolumes)]
         [Space(10)]
-        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes(Experimental)", Int) = 0
+        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes", Int) = 0
         _VRCLightVolumesStrength("VRCLightVolumesStrength", Range(0., 1.)) = 1.
 
         //------------------------------------------------------------------------------------------------------------------------------
@@ -256,7 +257,10 @@ Shader "FuchidoriPopToon/Cutout"
                 g2f o;
                 UNITY_INITIALIZE_OUTPUT(g2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                o = vert_outlinebase(v, _InnerOutlineWidth);
+                o = vert_main_pass(v);
+                o.pos.xy += (_VertexColorNormal == 1) ?
+                    CalculateOffsetVectorVertex(v.color, v.normalOS, v.tangent, v.uv, v.vertex)*_InnerOutlineWidth:
+                    CalculateOffsetVectorNormal(v.normalOS, v.uv)*_InnerOutlineWidth;
                 o.color = _InnerOutlineColor;
                 return o;
             }
@@ -307,7 +311,8 @@ Shader "FuchidoriPopToon/Cutout"
             {
                 v2f_shadow o;
                 TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
-                o.pos = CalculateOutlineVertex(v.normal, v.texcoord.xy, v.vertex, _OuterOutlineWidth);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.pos.xy += CalculateOffsetVectorNormal(v.normal, v.texcoord.xy)*_OuterOutlineWidth;
                 o.uv = v.texcoord.xy;
                 o.screenPos = ComputeScreenPos(o.pos);
                 return o;

--- a/Sources/FuchidoriPopToon_Cutout.shader
+++ b/Sources/FuchidoriPopToon_Cutout.shader
@@ -257,7 +257,7 @@ Shader "FuchidoriPopToon/Cutout"
                 g2f o;
                 UNITY_INITIALIZE_OUTPUT(g2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                o = vert_main_pass(v);
+                o = vert_outlinebase(v);
                 o.pos.xy += (_VertexColorNormal == 1) ?
                     CalculateOffsetVectorVertex(v.color, v.normalOS, v.tangent, v.uv, v.vertex)*_InnerOutlineWidth:
                     CalculateOffsetVectorNormal(v.normalOS, v.uv)*_InnerOutlineWidth;

--- a/Sources/FuchidoriPopToon_Opaque.shader
+++ b/Sources/FuchidoriPopToon_Opaque.shader
@@ -55,6 +55,7 @@ Shader "FuchidoriPopToon/Opaque"
         _OuterOutlineRatio("OuterOutlineRatio", Range(.01, 1.)) = .3
         _InnerOutlineWidth("InnerOutlineWidth", Float) = .0015
         _OutlineMask("OutlineMask", 2D) = "white" {}
+        [Toggle(_)] _VertexColorNormal("VertexColorNormal", Int) = 0
         _AsOutlineUnlit("As OutlineUnlit", Range(0,1)) = 0.5
 
         [Header(Transparent)]
@@ -67,9 +68,9 @@ Shader "FuchidoriPopToon/Opaque"
         _EmissiveTex("EmissiveTex", 2D) = "black" {}
         [HDR] _EmissiveColor("EmissiveColor", Color) = (1., 1., 1., 1.)
 
-        [Header(ExperimentalFeature)]
+        [Header(VRCLightVolumes)]
         [Space(10)]
-        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes(Experimental)", Int) = 0
+        [Toggle(_)] _VRCLightVolumesOn("VRCLightVolumes", Int) = 0
         _VRCLightVolumesStrength("VRCLightVolumesStrength", Range(0., 1.)) = 1.
 
         //------------------------------------------------------------------------------------------------------------------------------
@@ -257,7 +258,10 @@ Shader "FuchidoriPopToon/Opaque"
                 g2f o;
                 UNITY_INITIALIZE_OUTPUT(g2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                o = vert_outlinebase(v, _InnerOutlineWidth);
+                o = vert_main_pass(v);
+                o.pos.xy += (_VertexColorNormal == 1) ?
+                    CalculateOffsetVectorVertex(v.color, v.normalOS, v.tangent, v.uv, v.vertex)*_InnerOutlineWidth:
+                    CalculateOffsetVectorNormal(v.normalOS, v.uv)*_InnerOutlineWidth;
                 o.color = _InnerOutlineColor;
                 return o;
             }
@@ -304,7 +308,8 @@ Shader "FuchidoriPopToon/Opaque"
             {
                 v2f_shadow o;
                 TRANSFER_SHADOW_CASTER_NORMALOFFSET(o)
-                o.pos = CalculateOutlineVertex(v.normal, v.texcoord.xy, v.vertex, _OuterOutlineWidth);
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.pos.xy += CalculateOffsetVectorNormal(v.normal, v.texcoord.xy)*_OuterOutlineWidth;
                 o.uv = v.texcoord.xy;
                 o.screenPos = ComputeScreenPos(o.pos);
                 return o;

--- a/Sources/FuchidoriPopToon_Opaque.shader
+++ b/Sources/FuchidoriPopToon_Opaque.shader
@@ -258,7 +258,7 @@ Shader "FuchidoriPopToon/Opaque"
                 g2f o;
                 UNITY_INITIALIZE_OUTPUT(g2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                o = vert_main_pass(v);
+                o = vert_outlinebase(v);
                 o.pos.xy += (_VertexColorNormal == 1) ?
                     CalculateOffsetVectorVertex(v.color, v.normalOS, v.tangent, v.uv, v.vertex)*_InnerOutlineWidth:
                     CalculateOffsetVectorNormal(v.normalOS, v.uv)*_InnerOutlineWidth;

--- a/Sources/FuchidoriPopToon_Transparent.shader
+++ b/Sources/FuchidoriPopToon_Transparent.shader
@@ -256,7 +256,7 @@ Shader "FuchidoriPopToon/Transparent"
                 g2f o;
                 UNITY_INITIALIZE_OUTPUT(g2f, o);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
-                o = vert_main_pass(v);
+                o = vert_outlinebase(v);
                 o.pos.xy += (_VertexColorNormal == 1) ?
                     CalculateOffsetVectorVertex(v.color, v.normalOS, v.tangent, v.uv, v.vertex)*_InnerOutlineWidth:
                     CalculateOffsetVectorNormal(v.normalOS, v.uv)*_InnerOutlineWidth;


### PR DESCRIPTION
表題通り、頂点カラーにアウトライン用のノーマル情報をベイクする方法に対応します。

[焼きこみツール](https://github.com/lilxyzw/lilOutlineUtil)の使用を前提として、頂点カラーからの読み込みオプションが選択された場合に、モデルのアウトライン用のノーマルをアウトライン描画時に使用するようにします。